### PR TITLE
tune go server - handle 60,000 requests a minute

### DIFF
--- a/Project/http_server/index.html
+++ b/Project/http_server/index.html
@@ -21,7 +21,7 @@
         <p>
             Welcome to the Report Server. Reports are being gathered in real time
             by a service listening on TCP port 8090. The service is written in GO
-            Language and is capable of handling over over 40,000 requests in under
+            Language and is capable of handling over over 60,000 requests in under
             five seconds when running on fast hardware.
         </p>
         </p> Each report contains the following </p>

--- a/Project/server/src/Database.go
+++ b/Project/server/src/Database.go
@@ -5,24 +5,36 @@ import (
 )
 
 
-// Write a report to the database
-func writeToDatabase(h string, s string, t string) {
-
+//
+// Create table if not exists
+//
+func createDB() {
   // Connect to database
   dbconn, err := sql.Open("mysql", "reportuser:password@/report?charset=utf8")
   checkError(err)
   defer dbconn.Close()
 
-  // Create table if not exist
+  // Create table
   _, err = dbconn.Exec("CREATE TABLE IF NOT EXISTS reports " +
                        " (id int AUTO_INCREMENT PRIMARY KEY, " +
                        "hostname varchar(50), " +
                        "status varchar(10), " +
                        "timestamp varchar(50))")
   checkError(err)
+}
 
+
+//
+// Write a report to the database
+//
+func writeToDatabase(h string, s string, t string) {
   // Format the values by adding single quotes
   var vals = "'" + h + "'" + "," + "'" + s + "'" + "," + "'" + t + "'"
+
+  // Connect to database
+  dbconn, err := sql.Open("mysql", "reportuser:password@/report?charset=utf8")
+  checkError(err)
+  defer dbconn.Close()
 
   // SQL INSERT
   _, err = dbconn.Exec("INSERT INTO reports (hostname,status,timestamp) VALUES (" + vals + ")")

--- a/Project/server/src/WebServer.go
+++ b/Project/server/src/WebServer.go
@@ -10,13 +10,18 @@ import (
 
 // Main routing accepts each connection as a GO routine
 func main() {
+  // Ensure table is created in database
+  createDB()
+
+  // Start listener
   socket, err := net.Listen("tcp", ":8090")
   checkError(err)
 
+  // Handle each connection
   for {
     connection, err := socket.Accept()
     checkError(err)
-    go handleClient(connection)
+    handleClient(connection)
   }
 }
 
@@ -36,7 +41,7 @@ func handleClient(c net.Conn) {
 
     // Check status & write to database
     go statusCheck(hostname, status, timestamp)
-    go writeToDatabase(hostname, status, timestamp)
+    writeToDatabase(hostname, status, timestamp)
 
   } else {
     return


### PR DESCRIPTION
GO server is now capable of handling 60,000 incoming requests every 60 seconds. I have not implemented any channels, simply using the 'go' keyword. calling 'handleclient()' as a GO routine is significantly faster (1 million requests a minute) but the database cannot keep up. Proper DB tuning and GO channels would resolve this. 